### PR TITLE
アイディアソンのコメントに対しての評価機能を実装

### DIFF
--- a/backend/app/models/policy_proposal/policy_proposal_comment.py
+++ b/backend/app/models/policy_proposal/policy_proposal_comment.py
@@ -43,9 +43,32 @@ class PolicyProposalComment(Base):
 
     # 投稿日時（JST）
     posted_at = Column(DateTime, default=lambda: datetime.now(JST))
+    
+    # 更新日時（JST） - 一時的にコメントアウト（DBマイグレーション後有効化）
+    # updated_at = Column(DateTime, default=lambda: datetime.now(JST), onupdate=lambda: datetime.now(JST))
 
     # いいね数（初期値0）
     like_count = Column(Integer, default=0)
 
     # ソフトデリート（論理削除）
     is_deleted = Column(Boolean, default=False)
+    
+    # 評価関連（NULL可）
+    evaluation = Column(Integer, nullable=True)  # 純粋な評価（1-5：悪い-良い）
+    stance = Column(Integer, nullable=True)      # スタンス（1-5：否定的-肯定的）
+    
+    # 評価制約
+    __table_args__ = (
+        CheckConstraint(
+            "author_type IN ('admin', 'staff', 'contributor', 'viewer')",
+            name="check_author_type"
+        ),
+        CheckConstraint(
+            "evaluation IS NULL OR (evaluation >= 1 AND evaluation <= 5)",
+            name="check_evaluation_range"
+        ),
+        CheckConstraint(
+            "stance IS NULL OR (stance >= 1 AND stance <= 5)",
+            name="check_stance_range"
+        ),
+    )

--- a/backend/app/schemas/policy_proposal_comment.py
+++ b/backend/app/schemas/policy_proposal_comment.py
@@ -11,6 +11,8 @@ class PolicyProposalCommentCreate(BaseModel):
     author_id: UUID
     comment_text: str
     parent_comment_id: Optional[UUID] = None
+    evaluation: Optional[int] = Field(None, ge=1, le=5)  # 純粋な評価（1-5：悪い-良い）
+    stance: Optional[int] = Field(None, ge=1, le=5)      # スタンス（1-5：否定的-肯定的）
 
 # 既存：単一コメント
 class PolicyProposalCommentResponse(BaseModel):
@@ -21,8 +23,11 @@ class PolicyProposalCommentResponse(BaseModel):
     comment_text: str
     parent_comment_id: Optional[UUID]
     posted_at: datetime
+    # updated_at: Optional[datetime] = None  # 一時的にコメントアウト（DBマイグレーション後有効化）
     like_count: int
     is_deleted: bool
+    evaluation: Optional[int] = None  # 純粋な評価（1-5：悪い-良い）
+    stance: Optional[int] = None      # スタンス（1-5：否定的-肯定的）
 
     model_config = {
         # Pydantic v2 で ORM 変換を許可
@@ -34,6 +39,8 @@ class PolicyProposalReplyCreate(BaseModel):
     author_type: Literal["admin", "staff", "contributor", "viewer"]
     author_id: UUID
     comment_text: str
+    evaluation: Optional[int] = Field(None, ge=1, le=5)  # 純粋な評価（1-5：悪い-良い）
+    stance: Optional[int] = Field(None, ge=1, le=5)      # スタンス（1-5：否定的-肯定的）
 
 # AI 返信リクエスト
 class AIReplyRequest(BaseModel):
@@ -41,6 +48,22 @@ class AIReplyRequest(BaseModel):
     author_id: UUID
     persona: Optional[str] = "丁寧で建設的な政策担当者"
     instruction: Optional[str] = None
+
+# 評価投稿用スキーマ
+class CommentRatingCreate(BaseModel):
+    evaluation: Optional[int] = Field(None, ge=1, le=5)  # 純粋な評価（1-5：悪い-良い）
+    stance: Optional[int] = Field(None, ge=1, le=5)      # スタンス（1-5：否定的-肯定的）
+
+# 評価レスポンス用スキーマ
+class CommentRatingResponse(BaseModel):
+    id: UUID
+    evaluation: Optional[int] = None
+    stance: Optional[int] = None
+    updated_at: datetime
+
+    model_config = {
+        "from_attributes": True
+    }
 
 # 政策ごとに束ねる器（拡張メタ付き）
 class PolicyWithComments(BaseModel):


### PR DESCRIPTION
## 概要
PolicyProposalCommentに評価機能を追加し、ユーザーがコメントに対して評価とスタンスを設定できるようになりました。

## 実装内容

### モデル更新
- `PolicyProposalComment`モデルに評価カラムを追加
  - `evaluation`: 純粋な評価（1-5：悪い-良い）
  - `stance`: スタンス（1-5：否定的-肯定的）
- 評価値の範囲制約を追加（1-5の範囲）

### スキーマ追加
- `CommentRatingCreate`: 評価投稿用スキーマ
- `CommentRatingResponse`: 評価レスポンス用スキーマ
- 既存スキーマに評価フィールドを追加

### CRUD機能
- `update_comment_rating`: 評価更新関数
- 範囲チェック機能（1-5の制約）
- 部分更新対応（evaluation/stance個別更新可能）

### APIエンドポイント
- `PUT /api/policy-proposal-comments/{comment_id}/rating`
- 評価のみの操作（コメント本文は変更しない）
- 詳細なSwaggerUIドキュメント

## 技術的な注意点
- `updated_at`カラムは一時的にコメントアウト（DBマイグレーション後有効化予定）
- 評価値の範囲チェック（1-5）を実装
- エラーハンドリングを追加

## テスト
- 評価機能のAPIテスト完了
- サーバー起動確認済み

## 次のステップ
- DBマイグレーションの実行
- `updated_at`カラムの有効化