### PR TITLE
feat: 認証ログインAPIにレート制限を実装

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -14,12 +14,22 @@ from app.core.security.audit import AuditService, AuditEventType
 from app.db.session import get_db
 from app.models.user import User
 from app.models.expert import Expert
+from app.core.security.rate_limit.dependencies import check_auth_login_rate_limit
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
 # User/ExpertログインAPI (ユーザー認証を行い、アクセストークン（JWT）を発行して返す)
 @router.post("/login", response_model=TokenResponse)
-def login_user(http_request: Request, request: LoginRequest, db: Session = Depends(get_db)):
+def login_user(
+    http_request: Request, 
+    request: LoginRequest, 
+    db: Session = Depends(get_db),
+    rate_limit_check: bool = Depends(check_auth_login_rate_limit)  # レート制限チェック
+):
+    
+    # デバッグログを追加
+    print(" ログイン関数が呼び出されました")
+    print(f"🔍 リクエストIP: {http_request.client.host if http_request.client else 'unknown'}")
 
     # 監査サービスの初期化
     audit_service = AuditService(db)

--- a/backend/app/core/security/__init__.py
+++ b/backend/app/core/security/__init__.py
@@ -17,6 +17,13 @@ from .rbac import RBACService, require_user_permissions, require_expert_permissi
 # 監査ログ関連の機能をエクスポート
 from .audit import AuditService, AuditEventType, audit_log, audit_log_sync
 
+# レート制限関連の機能をエクスポート
+from .rate_limit import (
+    rate_limit, rate_limit_ip, rate_limit_endpoint, rate_limit_user,
+    rate_limit_auth_login, rate_limit_user_register, rate_limit_file_upload,
+    rate_limit_comment_post, rate_limit_read_api
+)
+
 __all__ = [
     "hash_password",
     "verify_password",
@@ -31,5 +38,14 @@ __all__ = [
     "AuditService",
     "AuditEventType",
     "audit_log",
-    "audit_log_sync"
+    "audit_log_sync",
+    "rate_limit",
+    "rate_limit_ip",
+    "rate_limit_endpoint",
+    "rate_limit_user",
+    "rate_limit_auth_login",
+    "rate_limit_user_register",
+    "rate_limit_file_upload",
+    "rate_limit_comment_post",
+    "rate_limit_read_api"
 ]

--- a/backend/app/core/security/rate_limit/__init__.py
+++ b/backend/app/core/security/rate_limit/__init__.py
@@ -1,0 +1,37 @@
+# レート制限サービスクラスをエクスポート
+from .service import RateLimitService
+
+# レート制限デコレータをエクスポート
+from .decorators import (
+    rate_limit, 
+    rate_limit_ip, 
+    rate_limit_endpoint, 
+    rate_limit_user,
+    rate_limit_auth_login,
+    rate_limit_user_register,
+    rate_limit_file_upload,
+    rate_limit_comment_post,
+    rate_limit_read_api
+)
+
+# レート制限設定をエクスポート
+from .config import RateLimitConfig
+
+# レート制限モデルをエクスポート
+from .models import RateLimitRule, RateLimitViolation
+
+__all__ = [
+    "RateLimitService",
+    "rate_limit",
+    "rate_limit_ip", 
+    "rate_limit_endpoint",
+    "rate_limit_user",
+    "rate_limit_auth_login",
+    "rate_limit_user_register",
+    "rate_limit_file_upload",
+    "rate_limit_comment_post",
+    "rate_limit_read_api",
+    "RateLimitConfig",
+    "RateLimitRule",
+    "RateLimitViolation"
+]

--- a/backend/app/core/security/rate_limit/config.py
+++ b/backend/app/core/security/rate_limit/config.py
@@ -1,0 +1,63 @@
+"""
+レート制限の設定管理
+"""
+
+from pydantic import BaseModel, Field
+from typing import Dict, Any
+
+class RateLimitConfig(BaseModel):
+    """レート制限の設定"""
+    
+    # 基本設定
+    enabled: bool = Field(default=True, description="レート制限を有効にするか")
+    default_max_requests: int = Field(default=100, description="デフォルトの最大リクエスト数")
+    default_window_seconds: int = Field(default=60, description="デフォルトの時間枠（秒）")
+    
+    # ログインAPIの制限（3回間違えると1分間ログインできない）
+    auth_login_max_requests: int = Field(default=3, description="ログインの最大試行回数")
+    auth_login_window_seconds: int = Field(default=60, description="ログイン制限の時間枠（秒）")
+    
+    # ユーザー登録系APIの制限（厳格）
+    user_register_max_requests: int = Field(default=3, description="ユーザー登録の最大試行回数")
+    user_register_window_seconds: int = Field(default=3600, description="ユーザー登録制限の時間枠（秒）")
+    
+    # ファイルアップロード系APIの制限（厳格）
+    file_upload_max_requests: int = Field(default=10, description="ファイルアップロードの最大試行回数")
+    file_upload_window_seconds: int = Field(default=60, description="ファイルアップロード制限の時間枠（秒）")
+    
+    # 投稿系APIの制限（適度）
+    comment_post_max_requests: int = Field(default=20, description="コメント投稿の最大試行回数")
+    comment_post_window_seconds: int = Field(default=60, description="コメント投稿制限の時間枠（秒）")
+    
+    # 読み取り系APIの制限（緩い）
+    read_api_max_requests: int = Field(default=100, description="読み取りAPIの最大試行回数")
+    read_api_window_seconds: int = Field(default=60, description="読み取りAPI制限の時間枠（秒）")
+    
+    # グローバル制限
+    global_ip_max_requests: int = Field(default=1000, description="IPアドレス別のグローバル最大リクエスト数")
+    global_ip_window_seconds: int = Field(default=3600, description="グローバル制限の時間枠（秒）")
+    
+    # 監査設定
+    log_violations: bool = Field(default=True, description="レート制限違反をログに記録するか")
+    block_violations: bool = Field(default=True, description="レート制限違反をブロックするか")
+    
+    # エラーメッセージ
+    error_messages: Dict[str, str] = Field(
+        default={
+            "auth_login": "ログイン試行回数が上限に達しました。1分後に再試行してください。",
+            "user_register": "ユーザー登録試行回数が上限に達しました。1時間後に再試行してください。",
+            "file_upload": "ファイルアップロード回数が上限に達しました。1分後に再試行してください。",
+            "comment_post": "コメント投稿回数が上限に達しました。1分後に再試行してください。",
+            "read_api": "読み取りAPIの利用回数が上限に達しました。1分後に再試行してください。",
+            "global_limit": "リクエスト回数が上限に達しました。1時間後に再試行してください。"
+        },
+        description="エンドポイント別のエラーメッセージ"
+    )
+    
+    class Config:
+        """Pydantic設定"""
+        env_prefix = "RATE_LIMIT_"
+        case_sensitive = False
+
+# デフォルト設定インスタンス
+default_config = RateLimitConfig()

--- a/backend/app/core/security/rate_limit/decorators.py
+++ b/backend/app/core/security/rate_limit/decorators.py
@@ -1,0 +1,216 @@
+"""
+レート制限デコレータ
+FastAPIエンドポイントにレート制限を適用するためのデコレータ
+"""
+
+import functools
+from typing import Optional, Union
+from fastapi import Request, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from .service import rate_limit_service
+from .models import RateLimitRule, RateLimitType
+from .config import default_config
+
+def rate_limit(
+    max_requests: int,
+    window_seconds: int,
+    request_type: RateLimitType = RateLimitType.IP,
+    rule_name: Optional[str] = None,
+    error_message: Optional[str] = None,
+    custom_identifier: Optional[str] = None
+):
+    """
+    汎用レート制限デコレータ
+    
+    Args:
+        max_requests: 時間枠内での最大リクエスト数
+        window_seconds: 時間枠（秒）
+        request_type: 制限タイプ
+        rule_name: ルール名（監査ログ用）
+        error_message: カスタムエラーメッセージ
+        custom_identifier: カスタム識別子
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            # リクエストオブジェクトを取得（修正版）
+            request = None
+            
+            # kwargsからRequestオブジェクトを探す
+            for key, value in kwargs.items():
+                if isinstance(value, Request):
+                    request = value
+                    break
+            
+            # kwargsで見つからない場合、argsから探す
+            if not request:
+                for arg in args:
+                    if isinstance(arg, Request):
+                        request = arg
+                        break
+            
+            # リクエストオブジェクトが見つからない場合
+            if not request:
+                print(f"⚠️  レート制限デコレータ: Requestオブジェクトが見つかりません")
+                print(f"   args: {args}")
+                print(f"   kwargs: {kwargs}")
+                return await func(*args, **kwargs)
+            
+            print(f"🔍 レート制限デコレータ: Requestオブジェクトを発見")
+            
+            # ルール名を決定
+            rule_name_final = rule_name or f"{func.__name__}_{request_type.value}"
+            
+            # エラーメッセージを決定
+            error_message_final = error_message or default_config.error_messages.get(
+                request_type.value, 
+                "レート制限に達しました。しばらく待ってから再試行してください。"
+            )
+            
+            # レート制限ルールを作成
+            rule = RateLimitRule(
+                name=rule_name_final,
+                max_requests=max_requests,
+                window_seconds=window_seconds,
+                request_type=request_type,
+                error_message=error_message_final
+            )
+            
+            # レート制限チェック
+            is_allowed, violation = rate_limit_service.check_rate_limit(
+                request, rule, custom_identifier
+            )
+            
+            if not is_allowed:
+                # レート制限ヘッダーを設定
+                headers = {
+                    "X-RateLimit-Limit": str(max_requests),
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": str(int(violation.timestamp.timestamp() + window_seconds)),
+                    "Retry-After": str(window_seconds)
+                }
+                
+                return JSONResponse(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    content={
+                        "detail": error_message_final,
+                        "retry_after_seconds": window_seconds,
+                        "rule_name": rule_name_final
+                    },
+                    headers=headers
+                )
+            
+            # レート制限状況を取得
+            status_info = rate_limit_service.get_rate_limit_status(request, rule, custom_identifier)
+            
+            # レート制限ヘッダーを設定
+            headers = {
+                "X-RateLimit-Limit": str(max_requests),
+                "X-RateLimit-Remaining": str(status_info.remaining_requests),
+                "X-RateLimit-Reset": str(int(status_info.reset_time.timestamp()))
+            }
+            
+            # 元の関数を実行
+            response = await func(*args, **kwargs)
+            
+            # レスポンスにヘッダーを追加
+            if hasattr(response, 'headers'):
+                for key, value in headers.items():
+                    response.headers[key] = value
+            
+            return response
+        
+        return wrapper
+    return decorator
+
+def rate_limit_ip(
+    max_requests: int,
+    window_seconds: int,
+    rule_name: Optional[str] = None,
+    error_message: Optional[str] = None
+):
+    """IPベースのレート制限デコレータ"""
+    return rate_limit(
+        max_requests=max_requests,
+        window_seconds=window_seconds,
+        request_type=RateLimitType.IP,
+        rule_name=rule_name,
+        error_message=error_message
+    )
+
+def rate_limit_endpoint(
+    max_requests: int,
+    window_seconds: int,
+    rule_name: Optional[str] = None,
+    error_message: Optional[str] = None
+):
+    """エンドポイントベースのレート制限デコレータ"""
+    return rate_limit(
+        max_requests=max_requests,
+        window_seconds=window_seconds,
+        request_type=RateLimitType.ENDPOINT,
+        rule_name=rule_name,
+        error_message=error_message
+    )
+
+def rate_limit_user(
+    max_requests: int,
+    window_seconds: int,
+    rule_name: Optional[str] = None,
+    error_message: Optional[str] = None
+):
+    """ユーザーベースのレート制限デコレータ"""
+    return rate_limit(
+        max_requests=max_requests,
+        window_seconds=window_seconds,
+        request_type=RateLimitType.USER,
+        rule_name=rule_name,
+        error_message=error_message
+    )
+
+# プリセットデコレータ（よく使う設定）
+def rate_limit_auth_login():
+    """認証ログイン用のレート制限（1分間に5回まで）"""
+    return rate_limit_ip(
+        max_requests=default_config.auth_login_max_requests,
+        window_seconds=default_config.auth_login_window_seconds,
+        rule_name="auth_login",
+        error_message=default_config.error_messages["auth_login"]
+    )
+
+def rate_limit_user_register():
+    """ユーザー登録用のレート制限（1時間に3回まで）"""
+    return rate_limit_ip(
+        max_requests=default_config.user_register_max_requests,
+        window_seconds=default_config.user_register_window_seconds,
+        rule_name="user_register",
+        error_message=default_config.error_messages["user_register"]
+    )
+
+def rate_limit_file_upload():
+    """ファイルアップロード用のレート制限（1分間に10回まで）"""
+    return rate_limit_ip(
+        max_requests=default_config.file_upload_max_requests,
+        window_seconds=default_config.file_upload_window_seconds,
+        rule_name="file_upload",
+        error_message=default_config.error_messages["file_upload"]
+    )
+
+def rate_limit_comment_post():
+    """コメント投稿用のレート制限（1分間に20回まで）"""
+    return rate_limit_ip(
+        max_requests=default_config.comment_post_max_requests,
+        window_seconds=default_config.comment_post_window_seconds,
+        rule_name="comment_post",
+        error_message=default_config.error_messages["comment_post"]
+    )
+
+def rate_limit_read_api():
+    """読み取りAPI用のレート制限（1分間に100回まで）"""
+    return rate_limit_ip(
+        max_requests=default_config.read_api_max_requests,
+        window_seconds=default_config.read_api_window_seconds,
+        rule_name="read_api",
+        error_message=default_config.error_messages["read_api"]
+    )

--- a/backend/app/core/security/rate_limit/dependencies.py
+++ b/backend/app/core/security/rate_limit/dependencies.py
@@ -1,0 +1,45 @@
+"""
+レート制限の依存性注入
+"""
+
+from fastapi import Request, HTTPException, status, Depends
+from fastapi.responses import JSONResponse
+from .service import rate_limit_service
+from .models import RateLimitRule, RateLimitType
+from .config import default_config
+
+def check_auth_login_rate_limit(request: Request):
+    """認証ログインのレート制限チェック"""
+    
+    print(f"🔍 レート制限依存性: チェック開始")
+    
+    # レート制限ルールを作成
+    rule = RateLimitRule(
+        name="auth_login",
+        max_requests=default_config.auth_login_max_requests,
+        window_seconds=default_config.auth_login_window_seconds,
+        request_type=RateLimitType.IP,
+        error_message=default_config.error_messages["auth_login"]
+    )
+    
+    # レート制限チェック
+    is_allowed, violation = rate_limit_service.check_rate_limit(request, rule)
+    
+    if not is_allowed:
+        print(f"🚫 レート制限違反: {violation}")
+        # レート制限ヘッダーを設定
+        headers = {
+            "X-RateLimit-Limit": str(rule.max_requests),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": str(int(violation.timestamp.timestamp() + rule.window_seconds)),
+            "Retry-After": str(rule.window_seconds)
+        }
+        
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=rule.error_message,
+            headers=headers
+        )
+    
+    print(f"✅ レート制限チェック通過")
+    return True

--- a/backend/app/core/security/rate_limit/models.py
+++ b/backend/app/core/security/rate_limit/models.py
@@ -1,0 +1,78 @@
+"""
+レート制限のデータモデル
+"""
+
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
+from datetime import datetime
+from enum import Enum
+
+class RateLimitType(str, Enum):
+    """レート制限のタイプ"""
+    IP = "ip"
+    ENDPOINT = "endpoint"
+    USER = "user"
+    GLOBAL = "global"
+
+class RateLimitRule(BaseModel):
+    """レート制限ルール"""
+    
+    name: str = Field(description="ルール名")
+    max_requests: int = Field(description="最大リクエスト数")
+    window_seconds: int = Field(description="時間枠（秒）")
+    request_type: RateLimitType = Field(description="制限タイプ")
+    endpoint_pattern: Optional[str] = Field(default=None, description="エンドポイントパターン（ワイルドカード対応）")
+    error_message: Optional[str] = Field(default=None, description="カスタムエラーメッセージ")
+    enabled: bool = Field(default=True, description="ルールを有効にするか")
+    
+    class Config:
+        """Pydantic設定"""
+        use_enum_values = True
+
+class RateLimitViolation(BaseModel):
+    """レート制限違反の記録"""
+    
+    timestamp: datetime = Field(default_factory=datetime.utcnow, description="違反発生時刻")
+    identifier: str = Field(description="制限対象の識別子（IP、ユーザーID、エンドポイント）")
+    request_type: RateLimitType = Field(description="制限タイプ")
+    rule_name: str = Field(description="違反したルール名")
+    current_count: int = Field(description="現在のリクエスト数")
+    max_allowed: int = Field(description="許可される最大リクエスト数")
+    window_seconds: int = Field(description="制限の時間枠（秒）")
+    ip_address: Optional[str] = Field(default=None, description="クライアントIPアドレス")
+    user_agent: Optional[str] = Field(default=None, description="ユーザーエージェント")
+    endpoint: Optional[str] = Field(default=None, description="アクセスしたエンドポイント")
+    user_id: Optional[str] = Field(default=None, description="ユーザーID（認証済みの場合）")
+    
+    class Config:
+        """Pydantic設定"""
+        use_enum_values = True
+
+class RateLimitStatus(BaseModel):
+    """レート制限の現在の状況"""
+    
+    identifier: str = Field(description="制限対象の識別子")
+    request_type: RateLimitType = Field(description="制限タイプ")
+    current_count: int = Field(description="現在のリクエスト数")
+    max_allowed: int = Field(description="許可される最大リクエスト数")
+    remaining_requests: int = Field(description="残りのリクエスト数")
+    window_seconds: int = Field(description="制限の時間枠（秒）")
+    reset_time: datetime = Field(description="制限がリセットされる時刻")
+    is_blocked: bool = Field(description="現在ブロックされているか")
+    
+    class Config:
+        """Pydantic設定"""
+        use_enum_values = True
+
+class RateLimitStats(BaseModel):
+    """レート制限の統計情報"""
+    
+    total_requests: int = Field(description="総リクエスト数")
+    blocked_requests: int = Field(description="ブロックされたリクエスト数")
+    violations_count: int = Field(description="違反回数")
+    active_identifiers: int = Field(description="アクティブな識別子数")
+    last_violation: Optional[datetime] = Field(default=None, description="最後の違反時刻")
+    
+    class Config:
+        """Pydantic設定"""
+        use_enum_values = True

--- a/backend/app/core/security/rate_limit/service.py
+++ b/backend/app/core/security/rate_limit/service.py
@@ -1,0 +1,251 @@
+"""
+レート制限サービスクラス
+レート制限のビジネスロジックを管理
+"""
+
+import time
+from typing import Dict, Optional, List
+from collections import defaultdict, deque
+from datetime import datetime, timedelta
+from fastapi import Request
+
+from .models import RateLimitRule, RateLimitViolation, RateLimitStatus, RateLimitStats, RateLimitType
+from .config import RateLimitConfig
+
+class RateLimitService:
+    """レート制限のビジネスロジックを提供するサービス層"""
+    
+    def __init__(self, config: Optional[RateLimitConfig] = None):
+        self.config = config or RateLimitConfig()
+        
+        print(f"🔧 レート制限サービス初期化: {self.config}")  # デバッグログ
+        print(f"🔧 認証ログイン設定: {self.config.auth_login_max_requests}/{self.config.auth_login_window_seconds}")  # デバッグログ
+        
+        # リクエスト履歴の管理
+        self.ip_requests: Dict[str, deque] = defaultdict(lambda: deque())
+        self.endpoint_requests: Dict[str, deque] = defaultdict(lambda: deque())
+        self.user_requests: Dict[str, deque] = defaultdict(lambda: deque())
+        self.global_requests: Dict[str, deque] = defaultdict(lambda: deque())
+        
+        # 違反記録の管理
+        self.violations: List[RateLimitViolation] = []
+        
+        # 統計情報
+        self.stats = RateLimitStats(
+            total_requests=0,
+            blocked_requests=0,
+            violations_count=0,
+            active_identifiers=0
+        )
+    
+    def _get_client_ip(self, request: Request) -> str:
+        """クライアントのIPアドレスを取得"""
+        try:
+            # プロキシ経由の場合の対応
+            forwarded_for = request.headers.get("x-forwarded-for")
+            if forwarded_for:
+                return forwarded_for.split(",")[0].strip()
+            
+            real_ip = request.headers.get("x-real-ip")
+            if real_ip:
+                return real_ip
+            
+            return request.client.host if request.client else "unknown"
+        except Exception:
+            return "unknown"
+    
+    def _get_user_id_from_token(self, request: Request) -> Optional[str]:
+        """JWTトークンからユーザーIDを取得"""
+        try:
+            auth_header = request.headers.get("authorization")
+            if not auth_header or not auth_header.startswith("Bearer "):
+                return None
+            
+            token = auth_header.split(" ")[1]
+            # 簡易的なJWTデコード（実際の実装では適切な検証が必要）
+            import jwt
+            from app.core.config import settings
+            
+            payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+            return payload.get("sub")
+        except Exception:
+            return None
+    
+    def _cleanup_old_requests(self, requests_deque: deque, window_seconds: int):
+        """古いリクエストを削除"""
+        current_time = time.time()
+        while requests_deque and current_time - requests_deque[0] > window_seconds:
+            requests_deque.popleft()
+    
+    def check_rate_limit(
+        self,
+        request: Request,
+        rule: RateLimitRule,
+        custom_identifier: Optional[str] = None
+    ) -> tuple[bool, Optional[RateLimitViolation]]:
+        """レート制限をチェック"""
+        
+        print(f" レート制限チェック開始: {rule.name}")  # デバッグログ
+        
+        if not self.config.enabled or not rule.enabled:
+            print(f"⚠️  レート制限が無効: enabled={self.config.enabled}, rule.enabled={rule.enabled}")  # デバッグログ
+            return True, None
+        
+        # 識別子を決定
+        identifier = custom_identifier or self._get_identifier(request, rule.request_type)
+        print(f" 識別子: {identifier}, タイプ: {rule.request_type}")  # デバッグログ
+        
+        # 適切なリクエスト履歴を選択
+        requests_deque = self._get_requests_deque(rule.request_type, identifier)
+        
+        # 古いリクエストを削除
+        self._cleanup_old_requests(requests_deque, rule.window_seconds)
+        
+        # 制限チェック
+        current_count = len(requests_deque)
+        is_allowed = current_count < rule.max_requests
+        
+        print(f"📊 現在のカウント: {current_count}/{rule.max_requests}, 許可: {is_allowed}")  # デバッグログ
+        
+        if is_allowed:
+            # リクエストを記録
+            requests_deque.append(time.time())
+            print(f"✅ リクエスト記録: {len(requests_deque)}")  # デバッグログ
+        else:
+            # 違反を記録
+            violation = RateLimitViolation(
+                timestamp=datetime.utcnow(),
+                identifier=identifier,
+                request_type=rule.request_type,
+                rule_name=rule.name,
+                current_count=current_count,
+                max_allowed=rule.max_requests,
+                window_seconds=rule.window_seconds,
+                ip_address=self._get_client_ip(request),
+                user_agent=request.headers.get("user-agent"),
+                endpoint=str(request.url.path),
+                user_id=self._get_user_id_from_token(request)
+            )
+            self.violations.append(violation)
+            print(f"🚫 レート制限違反記録: {violation}")  # デバッグログ
+        
+        return is_allowed, None if is_allowed else violation
+    
+    def _get_identifier(self, request: Request, request_type: RateLimitType) -> str:
+        """リクエストタイプに基づいて識別子を取得"""
+        if request_type == RateLimitType.IP:
+            return self._get_client_ip(request)
+        elif request_type == RateLimitType.ENDPOINT:
+            return f"{request.method}:{request.url.path}"
+        elif request_type == RateLimitType.USER:
+            user_id = self._get_user_id_from_token(request)
+            return user_id or self._get_client_ip(request)
+        elif request_type == RateLimitType.GLOBAL:
+            return self._get_client_ip(request)
+        else:
+            return "unknown"
+    
+    def _get_requests_deque(self, request_type: RateLimitType, identifier: str) -> deque:
+        """リクエストタイプに基づいて適切なdequeを取得"""
+        if request_type == RateLimitType.IP:
+            return self.ip_requests[identifier]
+        elif request_type == RateLimitType.ENDPOINT:
+            return self.endpoint_requests[identifier]
+        elif request_type == RateLimitType.USER:
+            return self.user_requests[identifier]
+        elif request_type == RateLimitType.GLOBAL:
+            return self.global_requests[identifier]
+        else:
+            return deque()
+    
+    def get_rate_limit_status(
+        self,
+        request: Request,
+        rule: RateLimitRule,
+        custom_identifier: Optional[str] = None
+    ) -> RateLimitStatus:
+        """レート制限の現在の状況を取得"""
+        identifier = custom_identifier or self._get_identifier(request, rule.request_type)
+        requests_deque = self._get_requests_deque(rule.request_type, identifier)
+        
+        # 古いリクエストを削除
+        self._cleanup_old_requests(requests_deque, rule.window_seconds)
+        
+        current_count = len(requests_deque)
+        remaining_requests = max(0, rule.max_requests - current_count)
+        
+        # リセット時刻を計算
+        if requests_deque:
+            oldest_request = requests_deque[0]
+            reset_time = datetime.fromtimestamp(oldest_request + rule.window_seconds)
+        else:
+            reset_time = datetime.utcnow()
+        
+        return RateLimitStatus(
+            identifier=identifier,
+            request_type=rule.request_type,
+            current_count=current_count,
+            max_allowed=rule.max_requests,
+            remaining_requests=remaining_requests,
+            window_seconds=rule.window_seconds,
+            reset_time=reset_time,
+            is_blocked=current_count >= rule.max_requests
+        )
+    
+    def get_stats(self) -> RateLimitStats:
+        """統計情報を取得"""
+        # アクティブな識別子数を計算
+        active_identifiers = (
+            len(self.ip_requests) + 
+            len(self.endpoint_requests) + 
+            len(self.user_requests) + 
+            len(self.global_requests)
+        )
+        
+        # 最後の違反時刻を取得
+        last_violation = None
+        if self.violations:
+            last_violation = max(violation.timestamp for violation in self.violations)
+        
+        return RateLimitStats(
+            total_requests=self.stats.total_requests,
+            blocked_requests=self.stats.blocked_requests,
+            violations_count=self.stats.violations_count,
+            active_identifiers=active_identifiers,
+            last_violation=last_violation
+        )
+    
+    def reset_limits(self):
+        """すべてのレート制限をリセット（テスト用）"""
+        self.ip_requests.clear()
+        self.endpoint_requests.clear()
+        self.user_requests.clear()
+        self.global_requests.clear()
+        self.violations.clear()
+        self.stats = RateLimitStats(
+            total_requests=0,
+            blocked_requests=0,
+            violations_count=0,
+            active_identifiers=0
+        )
+    
+    def cleanup_old_data(self, max_age_hours: int = 24):
+        """古いデータをクリーンアップ"""
+        cutoff_time = time.time() - (max_age_hours * 3600)
+        
+        # 古いリクエスト履歴を削除
+        for requests_dict in [self.ip_requests, self.endpoint_requests, self.user_requests, self.global_requests]:
+            for identifier in list(requests_dict.keys()):
+                requests_deque = requests_dict[identifier]
+                self._cleanup_old_requests(requests_deque, max_age_hours * 3600)
+                if not requests_deque:
+                    del requests_dict[identifier]
+        
+        # 古い違反記録を削除
+        self.violations = [
+            v for v in self.violations 
+            if v.timestamp.timestamp() > cutoff_time
+        ]
+
+# グローバルなレート制限サービスインスタンス
+rate_limit_service = RateLimitService()


### PR DESCRIPTION
- 1分間に3回までのログイン試行を制限
- IPアドレスベースのレート制限
- 依存性注入を使用した実装