### PR TITLE
feat: 政策提案APIに政策タグ情報を追加

### DIFF
--- a/backend/app/api/routes/policy_proposal.py
+++ b/backend/app/api/routes/policy_proposal.py
@@ -135,9 +135,10 @@ def get_policy_proposals(
     - status でのフィルタ
     - タイトル/本文の部分一致検索
     - created_at の降順で返却
+    - 政策タグ情報も含めて返却
     """
     rows = list_proposals(db=db, status_filter=status, q=q, offset=offset, limit=limit)
-    return rows
+    return [ProposalOut.from_proposal_with_relations(proposal) for proposal in rows]
 
 
 # 政策案の詳細取得
@@ -145,11 +146,12 @@ def get_policy_proposals(
 def get_policy_proposal_detail(proposal_id: str, db: Session = Depends(get_db)):
     """
     主キー（UUID文字列）を指定して政策案の詳細を取得する。
+    政策タグ情報も含めて返却する。
     """
     proposal = get_proposal(db=db, proposal_id=proposal_id)
     if not proposal:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Policy proposal not found")
-    return proposal
+    return ProposalOut.from_proposal_with_relations(proposal)
 
 
 # 政策案のコメント一覧取得

--- a/backend/app/models/policy_proposal/policy_proposal.py
+++ b/backend/app/models/policy_proposal/policy_proposal.py
@@ -49,3 +49,10 @@ class PolicyProposal(Base):
         back_populates="proposal",
         cascade="all, delete-orphan",
     )
+
+    # 政策タグ（多対多）
+    tags = relationship(
+        "PolicyProposalsPolicyTags",
+        back_populates="proposal",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/schemas/policy_proposal/policy_proposal.py
+++ b/backend/app/schemas/policy_proposal/policy_proposal.py
@@ -1,11 +1,23 @@
 # app/schemas/policy_proposal/policy_proposal.py
 from pydantic import BaseModel, Field
-from typing import Literal
+from typing import Literal, List
 from datetime import datetime
 from uuid import UUID
 
 # 投稿ステータスを定義
 PolicyStatus = Literal["draft", "published", "archived"]
+
+# 政策タグ用スキーマ
+class PolicyTagOut(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    keywords: str | None = None
+    created_at: datetime
+
+    model_config = {
+        "from_attributes": True
+    }
 
 # 政策案新規登録用スキーマ
 class ProposalCreate(BaseModel):
@@ -49,7 +61,41 @@ class ProposalOut(BaseModel):
     updated_at: datetime
     # 添付一覧（省略可能）
     attachments: list[AttachmentOut] | None = None
+    # 政策タグ一覧（省略可能）
+    policy_tags: list[PolicyTagOut] | None = None
 
     model_config = {
         "from_attributes": True
     }
+
+    @classmethod
+    def from_proposal_with_relations(cls, proposal):
+        """
+        政策提案オブジェクトからレスポンス用オブジェクトを作成
+        政策タグ情報も含めて適切にマッピングする
+        """
+        # 基本情報
+        data = {
+            "id": proposal.id,
+            "title": proposal.title,
+            "body": proposal.body,
+            "published_by_user_id": proposal.published_by_user_id,
+            "status": proposal.status,
+            "published_at": proposal.published_at,
+            "created_at": proposal.created_at,
+            "updated_at": proposal.updated_at,
+        }
+        
+        # 添付ファイル情報
+        if hasattr(proposal, 'attachments') and proposal.attachments:
+            data["attachments"] = [AttachmentOut.from_orm(att) for att in proposal.attachments]
+        else:
+            data["attachments"] = None
+            
+        # 政策タグ情報
+        if hasattr(proposal, 'tags') and proposal.tags:
+            data["policy_tags"] = [PolicyTagOut.from_orm(tag.tag) for tag in proposal.tags if tag.tag]
+        else:
+            data["policy_tags"] = None
+            
+        return cls(**data)


### PR DESCRIPTION
## 📋 概要
政策提案一覧取得・詳細取得APIのレスポンスに政策タグ情報を追加しました。

## 🔧 実装内容
- **ProposalOutスキーマ拡張**: `policy_tags`フィールドを追加
- **PolicyProposalモデル**: タグとのリレーション（`tags`）を追加
- **CRUD関数修正**: `joinedload`を使用して政策タグ情報を効率的に取得
- **レスポンスマッピング**: `from_proposal_with_relations`メソッドで適切にマッピング

## 📊 変更されたファイル
- `backend/app/schemas/policy_proposal/policy_proposal.py`
- `backend/app/models/policy_proposal/policy_proposal.py`
- `backend/app/crud/policy_proposal/policy_proposal.py`
- `backend/app/api/routes/policy_proposal.py`

## �� 影響範囲
- `GET /api/policy-proposals/` - 一覧取得時に政策タグ情報を含む
- `GET /api/policy-proposals/{id}` - 詳細取得時に政策タグ情報を含む

## �� レスポンス例
```json
{
  "id": "uuid",
  "title": "環境政策の提案",
  "policy_tags": [
    {
      "id": 1,
      "name": "環境政策",
      "description": "環境に関する政策",
      "keywords": "環境,CO2,再生可能エネルギー"
    }
  ]
}
```

## ✅ テスト
- 既存のエンドポイントの動作に影響なし
- 政策タグ情報が適切に含まれることを確認