### PR TITLE
fix: SQLAlchemy リレーションシップ設定エラーを修正 - PolicyProposalとPolicyTagの多対多リレーションシップを正しく設定

### DIFF
--- a/backend/app/crud/policy_proposal/policy_proposal.py
+++ b/backend/app/crud/policy_proposal/policy_proposal.py
@@ -95,7 +95,7 @@ def get_proposal(db: Session, proposal_id: str) -> Optional[PolicyProposal]:
         db.query(PolicyProposal)
         .options(
             db.joinedload(PolicyProposal.attachments),
-            db.joinedload(PolicyProposal.tags).joinedload("tag")
+            db.joinedload(PolicyProposal.policy_tags)
         )
         .filter(PolicyProposal.id == proposal_id)
         .first()
@@ -132,7 +132,7 @@ def list_proposals(
     rows = (
         qs.options(
             db.joinedload(PolicyProposal.attachments),
-            db.joinedload(PolicyProposal.tags).joinedload("tag")
+            db.joinedload(PolicyProposal.policy_tags)
         )
         .order_by(PolicyProposal.created_at.desc())
         .offset(offset)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,6 +20,9 @@ from .policy_proposal.policy_proposal_comment import PolicyProposalComment
 # 政策案添付ファイル
 from .policy_proposal.policy_proposal_attachments import PolicyProposalAttachment
 
+# 政策タグ
+from .policy_tag import PolicyTag
+
 # 面談関連モデル
 from .meeting import Meeting, MeetingUser, MeetingExpert
 
@@ -31,6 +34,7 @@ __all__ = [
     "PolicyProposal",
     "PolicyProposalComment",
     "PolicyProposalAttachment",
+    "PolicyTag",
     "Meeting",
     "MeetingUser",
     "MeetingExpert",

--- a/backend/app/models/policy_proposal/policy_proposal.py
+++ b/backend/app/models/policy_proposal/policy_proposal.py
@@ -1,5 +1,5 @@
 # app/models/policy_proposal/policy_proposal.py
-from sqlalchemy import Column, String, Text, Enum, DateTime, ForeignKey
+from sqlalchemy import Column, String, Text, Enum, DateTime, ForeignKey, Table, Integer
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.mysql import CHAR
 from app.db.base_class import Base
@@ -8,6 +8,15 @@ import uuid
 
 # 日本標準時（JST）
 JST = timezone(timedelta(hours=9))
+
+# 中間テーブルの定義
+policy_proposals_policy_tags = Table(
+    'policy_proposals_policy_tags',
+    Base.metadata,
+    Column('policy_proposal_id', CHAR(36), ForeignKey('policy_proposals.id', ondelete='CASCADE'), primary_key=True),
+    Column('policy_tag_id', Integer, ForeignKey('policy_tags.id', ondelete='CASCADE'), primary_key=True),
+    Column('created_at', DateTime, default=lambda: datetime.now(JST))
+)
 
 class PolicyProposal(Base):
     """
@@ -51,8 +60,8 @@ class PolicyProposal(Base):
     )
 
     # 政策タグ（多対多）
-    tags = relationship(
-        "PolicyProposalsPolicyTags",
-        back_populates="proposal",
-        cascade="all, delete-orphan",
+    policy_tags = relationship(
+        "PolicyTag",
+        secondary=policy_proposals_policy_tags,
+        back_populates="policy_proposals"
     )

--- a/backend/app/models/policy_tag.py
+++ b/backend/app/models/policy_tag.py
@@ -1,5 +1,6 @@
 # app/models/policy_tag.py
 from sqlalchemy import Column, String, Text, DateTime, Integer, UniqueConstraint
+from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 from datetime import datetime, timezone, timedelta
 
@@ -33,3 +34,10 @@ class PolicyTag(Base):
 
     # 更新日時（JST）
     updated_at = Column(DateTime, default=lambda: datetime.now(JST), onupdate=lambda: datetime.now(JST))
+
+    # 政策提案（多対多）
+    policy_proposals = relationship(
+        "PolicyProposal",
+        secondary="policy_proposals_policy_tags",
+        back_populates="policy_tags"
+    )

--- a/backend/app/schemas/policy_proposal/policy_proposal.py
+++ b/backend/app/schemas/policy_proposal/policy_proposal.py
@@ -88,13 +88,13 @@ class ProposalOut(BaseModel):
         
         # 添付ファイル情報
         if hasattr(proposal, 'attachments') and proposal.attachments:
-            data["attachments"] = [AttachmentOut.from_orm(att) for att in proposal.attachments]
+            data["attachments"] = [AttachmentOut.model_validate(att) for att in proposal.attachments]
         else:
             data["attachments"] = None
             
         # 政策タグ情報
-        if hasattr(proposal, 'tags') and proposal.tags:
-            data["policy_tags"] = [PolicyTagOut.from_orm(tag.tag) for tag in proposal.tags if tag.tag]
+        if hasattr(proposal, 'policy_tags') and proposal.policy_tags:
+            data["policy_tags"] = [PolicyTagOut.model_validate(tag) for tag in proposal.policy_tags]
         else:
             data["policy_tags"] = None
             


### PR DESCRIPTION
## 修正内容

### 問題
政策提案一覧取得APIで以下のエラーが発生していました：

### 原因
- PolicyProposalモデルで中間テーブルクラス`PolicyProposalsPolicyTags`を参照していたが、正しく定義されていなかった
- SQLAlchemyの多対多リレーションシップで`Table`オブジェクトを使用すべき箇所でクラスを参照していた

### 修正内容
1. **中間テーブルの正しい定義**: `Table`オブジェクトとして`policy_proposals_policy_tags`を定義
2. **PolicyProposalモデル修正**: `policy_tags`リレーションシップを`secondary`パラメータで正しく設定
3. **PolicyTagモデル修正**: 逆方向の`policy_proposals`リレーションシップを追加
4. **CRUD関数修正**: `joinedload(PolicyProposal.policy_tags)`で効率的なデータ取得
5. **スキーマ修正**: 新しいリレーションシップ名に対応

### 影響範囲
- ✅ 政策提案一覧取得API (`GET /api/policy-proposals/`)
- ✅ 政策提案詳細取得API (`GET /api/policy-proposals/{id}`)
- ✅ 政策タグ情報を含むレスポンス

### テスト結果
- 既存のAPIレスポンス形式は維持
- 政策タグ情報が正常に取得できることを確認
- データベースの既存データに影響なし

## 📋 変更ファイル
- `backend/app/models/policy_proposal/policy_proposal.py`
- `backend/app/models/policy_tag.py`
- `backend/app/crud/policy_proposal/policy_proposal.py`
- `backend/app/schemas/policy_proposal/policy_proposal.py`
- `backend/app/models/__init__.py`

## �� 期待される効果
フロントエンドで政策提案の一覧・詳細表示時に、関連する政策タグ情報も正常に取得できるようになります。