### PR TITLE
feat: 特定の政策提案に対するコメント数取得APIを実装

### DIFF
--- a/backend/COMMENT_COUNT_API.md
+++ b/backend/COMMENT_COUNT_API.md
@@ -1,0 +1,150 @@
+# PolicyProposalComments数取得API ドキュメント
+
+## 概要
+
+このドキュメントでは、PolicyProposalComments数取得APIの使用方法について説明します。フロントエンドのダッシュボードページでPolicyProposalComments数を表示するために実装されました。
+
+## 実装されたエンドポイント
+
+### 特定の政策提案に対するPolicyProposalComments数取得API
+
+**エンドポイント**: `GET /api/policy-proposal-comments/policy-proposals/{policy_proposal_id}/comment-count`
+
+**説明**: 特定の政策提案に対するPolicyProposalComments数を取得するAPI
+
+**パラメータ**:
+- `policy_proposal_id`: 政策提案ID（パスパラメータ）
+
+**レスポンス例**:
+```json
+{
+  "policy_proposal_id": "policy-001",
+  "comment_count": 157
+}
+```
+
+**レスポンスフィールド**:
+- `policy_proposal_id`: 政策提案ID
+- `comment_count`: その政策提案に対するPolicyProposalComments数
+
+## エラーハンドリング
+
+**エラーレスポンス**:
+```json
+{
+  "detail": "コメント数取得中にエラーが発生しました: エラー詳細"
+}
+```
+
+**想定されるエラー**:
+- `500`: サーバー内部エラー（データベース接続エラー等）
+
+## フロントエンド連携例
+
+### TypeScriptでの使用例
+
+```typescript
+// 特定の政策提案に対するPolicyProposalComments数取得
+const getCommentCount = async (policyId: string) => {
+  try {
+    const response = await fetch(`/api/policy-proposal-comments/policy-proposals/${policyId}/comment-count`);
+    const data = await response.json();
+    console.log('政策提案ID:', data.policy_proposal_id);
+    console.log('コメント数:', data.comment_count);
+    return data.comment_count;
+  } catch (error) {
+    console.error('エラー:', error);
+    return 0;
+  }
+};
+```
+
+### Reactでの使用例
+
+```tsx
+import React, { useState, useEffect } from 'react';
+
+interface CommentCount {
+  policy_proposal_id: string;
+  comment_count: number;
+}
+
+interface CommentCountComponentProps {
+  policyId: string;
+}
+
+const CommentCountComponent: React.FC<CommentCountComponentProps> = ({ policyId }) => {
+  const [commentCount, setCommentCount] = useState<number>(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCommentCount = async () => {
+      try {
+        const response = await fetch(`/api/policy-proposal-comments/policy-proposals/${policyId}/comment-count`);
+        const data: CommentCount = await response.json();
+        setCommentCount(data.comment_count);
+      } catch (error) {
+        console.error('データ取得エラー:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCommentCount();
+  }, [policyId]);
+
+  if (loading) {
+    return <div>読み込み中...</div>;
+  }
+
+  return (
+    <div>
+      <h2>コメント統計</h2>
+      <p>政策提案ID: {policyId}</p>
+      <p>コメント数: {commentCount}</p>
+    </div>
+  );
+};
+
+export default CommentCountComponent;
+```
+
+## テスト
+
+APIのテストは以下のコマンドで実行できます：
+
+```bash
+# サーバー起動
+cd backend
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+
+# 別ターミナルでテスト実行
+python test_comment_count_api.py
+```
+
+## 実装詳細
+
+### データベースクエリ
+
+```sql
+SELECT COUNT(*) FROM policy_proposal_comments 
+WHERE policy_proposal_id = 'policy-001' AND is_deleted = false;
+```
+
+### パフォーマンス考慮事項
+
+- 論理削除されたコメントは除外
+- シンプルなCOUNTクエリで高速実行
+- 必要に応じてインデックスを追加
+
+### セキュリティ
+
+- 入力値のバリデーション（不要）
+- SQLインジェクション対策（SQLAlchemy ORM使用）
+
+## 変更履歴
+
+- 2025-01-27: 初回実装
+  - 特定の政策提案に対するPolicyProposalComments数取得API
+  - シンプルなレスポンス形式
+  - 基本的なエラーハンドリング

--- a/backend/app/crud/policy_proposal/policy_proposal_comment.py
+++ b/backend/app/crud/policy_proposal/policy_proposal_comment.py
@@ -247,3 +247,27 @@ def update_comment_rating(
     db.commit()
     db.refresh(comment)
     return comment
+
+# コメント数取得関数
+def get_comment_count_by_policy_proposal(db: Session, policy_proposal_id: str) -> int:
+    """
+    特定の政策提案に対するPolicyProposalComments数を取得する。
+    
+    Args:
+        db: Database session
+        policy_proposal_id: 政策提案ID
+        
+    Returns:
+        int: その政策提案に対するコメント数
+    """
+    # コメント数（論理削除を除く）
+    comment_count = (
+        db.query(func.count(PolicyProposalComment.id))
+        .filter(
+            PolicyProposalComment.policy_proposal_id == policy_proposal_id,
+            PolicyProposalComment.is_deleted == False
+        )
+        .scalar()
+    ) or 0
+    
+    return comment_count

--- a/backend/app/schemas/policy_proposal_comment.py
+++ b/backend/app/schemas/policy_proposal_comment.py
@@ -94,3 +94,8 @@ class PolicyProposalCommentListResponse(BaseModel):
 
     latest_commented_at: Optional[datetime] = None
     total_comments: int
+
+# コメント数取得API用スキーマ
+class PolicyProposalCommentsCountResponse(BaseModel):
+    policy_proposal_id: str
+    comment_count: int

--- a/backend/test_comment_count_api.py
+++ b/backend/test_comment_count_api.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+PolicyProposalComments数取得APIのテストスクリプト
+"""
+
+import requests
+import json
+from datetime import datetime
+
+# ベースURL
+BASE_URL = "http://localhost:8000"
+
+def test_comment_count_api():
+    """特定の政策提案に対するPolicyProposalComments数取得APIのテスト"""
+    print("=== 特定の政策提案に対するPolicyProposalComments数取得APIテスト ===")
+    
+    # テスト用の政策提案ID（実際のIDに置き換える必要があります）
+    test_policy_id = "test-policy-001"
+    
+    try:
+        response = requests.get(f"{BASE_URL}/api/policy-proposal-comments/policy-proposals/{test_policy_id}/comment-count")
+        print(f"Status Code: {response.status_code}")
+        
+        if response.status_code == 200:
+            data = response.json()
+            print("レスポンス:")
+            print(json.dumps(data, indent=2, ensure_ascii=False))
+            print(f"政策提案ID: {data.get('policy_proposal_id', '')}")
+            print(f"コメント数: {data.get('comment_count', 0)}")
+        else:
+            print(f"エラー: {response.text}")
+            
+    except Exception as e:
+        print(f"エラー: {e}")
+    
+    print()
+
+def test_server_health():
+    """サーバーの健全性チェック"""
+    print("=== サーバー健全性チェック ===")
+    
+    try:
+        response = requests.get(f"{BASE_URL}/")
+        print(f"Status Code: {response.status_code}")
+        
+        if response.status_code == 200:
+            data = response.json()
+            print(f"レスポンス: {data}")
+        else:
+            print(f"エラー: {response.text}")
+            
+    except Exception as e:
+        print(f"エラー: {e}")
+    
+    print()
+
+def main():
+    """メイン関数"""
+    print("PolicyProposalComments数取得APIテスト開始")
+    print(f"テスト対象URL: {BASE_URL}")
+    print(f"テスト実行時刻: {datetime.now()}")
+    print("=" * 50)
+    
+    # サーバー健全性チェック
+    test_server_health()
+    
+    # コメント数取得APIテスト
+    test_comment_count_api()
+    
+    print("テスト完了")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
実装完了内容

✅ 実装した機能:
特定の政策提案に対するコメント数取得API
エンドポイント: GET /api/policy-proposal-comments/policy-proposals/{policy_proposal_id}/comment-count
レスポンス: {"policy_proposal_id": "xxx", "comment_count": 123}

✅ 追加したファイル:
COMMENT_COUNT_API.md - APIドキュメント
test_comment_count_api.py - テストスクリプト

✅ 修正したファイル:
app/schemas/policy_proposal_comment.py - レスポンススキーマ追加
app/crud/policy_proposal/policy_proposal_comment.py - CRUD関数追加
app/api/routes/policy_proposal_comment.py - APIエンドポイント追加