### PR TITLE
feat: 返信コメント取得エンドポイントの実装と最適化

### DIFF
--- a/backend/app/schemas/policy_proposal_comment.py
+++ b/backend/app/schemas/policy_proposal_comment.py
@@ -100,3 +100,25 @@ class PolicyProposalCommentListResponse(BaseModel):
 class PolicyProposalCommentsCountResponse(BaseModel):
     policy_proposal_id: str
     comment_count: int
+
+# 返信コメント取得用レスポンススキーマ
+class ReplyCommentResponse(BaseModel):
+    id: UUID
+    comment_text: str
+    author_type: Literal["admin", "staff", "contributor", "viewer"]
+    author_id: UUID
+    author_name: Optional[str] = None
+    posted_at: datetime
+    parent_comment_id: UUID
+
+    model_config = {
+        "from_attributes": True
+    }
+
+class RepliesResponse(BaseModel):
+    replies: List[ReplyCommentResponse]
+    total_count: int
+    has_more: bool
+
+class ReplyCountResponse(BaseModel):
+    reply_count: int


### PR DESCRIPTION
## 概要
フロントエンド側のパフォーマンス向上のため、返信コメント取得の専用エンドポイントを実装しました。

## 変更内容

### 新機能
- **返信コメント取得エンドポイント**: `GET /api/policy-proposal-comments/{parent_comment_id}/replies`
- **返信コメント件数取得エンドポイント**: `GET /api/policy-proposal-comments/{parent_comment_id}/replies/count`

### 最適化
- **CRUD関数のパフォーマンス最適化**: 重複クエリの削除
- **投稿者名取得の効率化**: 直接的なクエリに変更
- **UUID検証機能の追加**: 無効なリクエストの早期拒否

### 改善
- **エラーハンドリングの強化**: 詳細なエラーメッセージ
- **一貫したエラーレスポンス**: 統一されたエラーフォーマット

## 期待される効果
- フロントエンド側でのパフォーマンス向上
- データ転送量の削減
- レスポンス時間の短縮
- スケーラビリティの向上

## テスト
- [ ] 正常なUUIDでの返信コメント取得
- [ ] 無効なUUIDでのエラーハンドリング
- [ ] 存在しないコメントIDでのエラーハンドリング
- [ ] ページネーション機能の動作確認

## 関連Issue
フロントエンド側からの返信コメント取得エンドポイント開発要望